### PR TITLE
[darwin] Add homebrew tap for graphical

### DIFF
--- a/data/homebrew_graphical_taps.json
+++ b/data/homebrew_graphical_taps.json
@@ -1,0 +1,1 @@
+["homebrew/cask-fonts"]

--- a/lib/prep.sh
+++ b/lib/prep.sh
@@ -944,6 +944,7 @@ install_graphical_packages() {
       fi
       ;;
     Darwin)
+      darwin_add_homebrew_taps_from_json "$_data_path/homebrew_graphical_taps.json"
       darwin_install_cask_pkgs_from_json "$_data_path/darwin_graphical_cask_pkgs.json"
       darwin_install_apps_from_json "$_data_path/darwin_graphical_apps.json"
       killall Dock


### PR DESCRIPTION
This functionality was removed in
4289054bc64bfdffdd0f46b2e1f34a4d303f32f8, however it now appears that
taps are still required, at least as far as the Inconsolata font is
concerned. Rather than reverting the commit, a new caching behavior was
implemented to be on par with the other macOS package installation
logic.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>